### PR TITLE
Add SEO meta, mission section, and email notifications

### DIFF
--- a/app/actions/waitlist.ts
+++ b/app/actions/waitlist.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { saveWaitlistUser } from "@/lib/database"
+import { sendWaitlistEmail } from "@/lib/email"
 
 export async function submitWaitlistForm(formData: FormData) {
   try {
@@ -35,12 +36,19 @@ export async function submitWaitlistForm(formData: FormData) {
     }
 
     // Save to database
-    const result = await saveWaitlistUser({
+    const cleanData = {
       name: name.trim(),
       age,
       mobile: mobile.trim(),
       email: email.trim().toLowerCase(),
-    })
+    }
+
+    const result = await saveWaitlistUser(cleanData)
+
+    if (result.success) {
+      // Fire and forget email notification
+      sendWaitlistEmail(cleanData)
+    }
 
     if (result.success) {
       return {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,23 @@ export const metadata: Metadata = {
   title: "Oriyali | Your Biorhythm Story",
   description:
     "Decode your unique neuro-hormonal patterns with personalized, proactive insights to harmonize your mood, energy, and focus every day.",
+  keywords: [
+    "Oriyali",
+    "women's wellness",
+    "hormone tracking",
+    "biorhythm",
+    "wearable biometrics",
+  ],
+  metadataBase: new URL("https://oriyali.example.com"),
+  openGraph: {
+    title: "Oriyali | Your Biorhythm Story",
+    description:
+      "Decode your unique neuro-hormonal patterns with personalized, proactive insights to harmonize your mood, energy, and focus every day.",
+    url: "https://oriyali.example.com",
+    siteName: "Oriyali",
+    locale: "en_US",
+    type: "website",
+  },
   icons: {
     icon: [
       {
@@ -42,6 +59,7 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.png" type="image/png" />
         <link rel="apple-touch-icon" href="/favicon.png" />
+        <link rel="canonical" href="https://oriyali.example.com" />
       </head>
       <body className={`${sortsMillGoudy.className} antialiased`}>
         <ThemeProvider

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = ["hero", "why", "how", "what", "research"]
+      const sections = ["hero", "mission", "why", "how", "what", "research"]
       const scrollPosition = window.scrollY + 100
 
       for (const section of sections) {
@@ -63,6 +63,7 @@ export default function Home() {
 
   const navItems = [
     { id: "hero", label: "Home" },
+    { id: "mission", label: "Mission" },
     { id: "why", label: "Why" },
     { id: "how", label: "How" },
     { id: "what", label: "What" },
@@ -323,6 +324,26 @@ export default function Home() {
           >
             <ChevronDown size={32} className="text-white" />
           </motion.div>
+        </section>
+
+        {/* Mission Section */}
+        <section id="mission" className="py-16 md:py-24 bg-background" tabIndex={-1} aria-labelledby="mission-heading">
+          <div className="container mx-auto px-4 md:px-6">
+            <motion.div
+              initial={{ opacity: 0, y: 50 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8 }}
+              viewport={{ once: true }}
+              className="text-center mb-12 md:mb-16"
+            >
+              <h2 id="mission-heading" className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-light mb-4 md:mb-6 text-[#075056] dark:text-[#9ECFD6] px-4">
+                Our Goal & Mission
+              </h2>
+              <p className="text-lg md:text-xl text-foreground max-w-4xl mx-auto leading-relaxed px-4">
+                Oriyali Aura is your science-backed neuro-hormonal strategist for women. It fuses wearable biometrics, cycle cues, and AI to forecast your brain-body rhythms, then delivers minute-perfect micro-rituals and supplement prompts that boost mood, focus and resilience. Track periods, log symptoms, sync Apple Health, and watch the Neuro-Hormonal Readiness ring guide your day. Private, compassionate, and built to grow with you from puberty to post-menopause.
+              </p>
+            </motion.div>
+          </div>
         </section>
 
         {/* Why Section */}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -10,37 +10,50 @@ export interface WaitlistUser {
   createdAt?: Date
 }
 
-// Mock database function - replace with your actual database implementation
+// Simple JSON based storage for waitlist
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+const DATA_PATH = join(process.cwd(), 'data')
+const FILE_PATH = join(DATA_PATH, 'waitlist.json')
+
+// Ensure data directory exists
+async function ensureDataFile() {
+  try {
+    await fs.mkdir(DATA_PATH, { recursive: true })
+    await fs.access(FILE_PATH)
+  } catch {
+    await fs.writeFile(FILE_PATH, '[]')
+  }
+}
+
+// Save waitlist user to local JSON file
 export async function saveWaitlistUser(
   userData: Omit<WaitlistUser, "id" | "createdAt">,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    // Simulate database save operation
-    // Replace this with your actual database call (e.g., Supabase, Neon, etc.)
+    await ensureDataFile()
+    const raw = await fs.readFile(FILE_PATH, 'utf8')
+    const existing: WaitlistUser[] = JSON.parse(raw)
 
-    console.log("Saving user to waitlist:", userData)
+    const newUser: WaitlistUser = {
+      ...userData,
+      id: Date.now().toString(),
+      createdAt: new Date(),
+    }
 
-    // Simulate network delay
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    // Here you would typically:
-    // 1. Connect to your database
-    // 2. Insert the user data
-    // 3. Handle any validation or duplicate checking
-
-    // Example for different databases:
-    // Supabase: const { data, error } = await supabase.from('waitlist').insert([userData])
-    // Neon: const result = await sql`INSERT INTO waitlist (name, age, mobile, email) VALUES (${userData.name}, ${userData.age}, ${userData.mobile}, ${userData.email})`
+    existing.push(newUser)
+    await fs.writeFile(FILE_PATH, JSON.stringify(existing, null, 2))
 
     return {
       success: true,
-      message: "User successfully added to waitlist",
+      message: 'User successfully added to waitlist',
     }
   } catch (error) {
-    console.error("Error saving user to waitlist:", error)
+    console.error('Error saving user to waitlist:', error)
     return {
       success: false,
-      message: "Failed to save user data",
+      message: 'Failed to save user data',
     }
   }
 }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,33 @@
+import nodemailer from 'nodemailer'
+
+export interface WaitlistEmailData {
+  name: string
+  age: number
+  mobile: string
+  email: string
+}
+
+export async function sendWaitlistEmail(data: WaitlistEmailData) {
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: Number(process.env.EMAIL_PORT) || 587,
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    })
+
+    const message = {
+      from: process.env.EMAIL_FROM ?? process.env.EMAIL_USER,
+      to: process.env.WAITLIST_RECEIVER ?? 'durgeshkukreti27@gmail.com',
+      subject: 'New Waitlist Submission',
+      text: `Name: ${data.name}\nAge: ${data.age}\nMobile: ${data.mobile}\nEmail: ${data.email}`,
+    }
+
+    await transporter.sendMail(message)
+  } catch (error) {
+    console.error('Error sending waitlist email:', error)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "recharts": "latest",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "three": "latest"
+    "three": "latest",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- expand SEO metadata and canonical link
- add mission section with Oriyali Aura's goal and mission
- store waitlist submissions locally and send email notifications

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685400ffdb208325a54a1fc3d1256567