### PR TITLE
Pixel landing: Geist Pixel, ASCII product animation, logos, footer, lead magnet

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,4 +1,5 @@
 import { SiteNav } from "@/components/site/site-nav";
+import { SiteFooter } from "@/components/site/site-footer";
 
 export default function SiteLayout({
   children,
@@ -7,6 +8,7 @@ export default function SiteLayout({
     <>
       <SiteNav />
       {children}
+      <SiteFooter />
     </>
   );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -3,6 +3,8 @@ import { Marquee } from "@/registry/default/motion/marquee";
 import { ScrollRevealGrid } from "@/registry/default/motion/scroll-reveal-grid";
 import { Badge } from "@/registry/default/ui/badge";
 import { AgentDemo } from "@/components/site/agent-demo";
+import { AccessForm } from "@/components/site/access-form";
+import { AsciiShowcase } from "@/components/site/ascii-showcase";
 import { HeroIntro } from "@/components/site/hero-intro";
 import { InstallTabs } from "@/components/site/install-tabs";
 import { PreviewPanel } from "@/components/site/preview";
@@ -79,13 +81,32 @@ export default function HomePage() {
   return (
     <main>
       {/* Hero */}
-      <section className="mx-auto flex max-w-3xl flex-col items-center px-4 pb-12 pt-24 text-center">
+      <section className="mx-auto flex max-w-3xl flex-col items-center px-4 pb-10 pt-20 text-center">
         <HeroIntro />
       </section>
 
+      {/* The whole product, in pixels */}
+      <section className="mx-auto max-w-5xl px-4 pb-6">
+        <AsciiShowcase />
+        <p className="mt-3 text-center font-pixel text-[10px] uppercase tracking-widest text-muted-foreground">
+          The whole product, drawn in pixels — option chains, KYC, vitals, swaps, agents
+        </p>
+      </section>
+
       {/* Live implementation demo */}
-      <section className="mx-auto max-w-5xl px-4 pb-20">
-        <AgentDemo />
+      <section className="mx-auto max-w-5xl px-4 py-14">
+        <ScrollFade>
+          <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
+            And here it is for real.
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            The same system, running: an agent connected over MCP discovers,
+            installs and renders a working component.
+          </p>
+        </ScrollFade>
+        <div className="mt-6">
+          <AgentDemo />
+        </div>
       </section>
 
       <section className="border-y border-border py-10">
@@ -104,7 +125,7 @@ export default function HomePage() {
       {/* Built for agents */}
       <section className="mx-auto max-w-5xl px-4 py-20">
         <ScrollFade>
-          <h2 className="max-w-2xl text-2xl font-semibold tracking-tight">
+          <h2 className="max-w-2xl font-pixel text-xl uppercase tracking-wide sm:text-2xl">
             Your coding agent can see the system, not just the screenshot.
           </h2>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -135,7 +156,7 @@ export default function HomePage() {
       <section className="border-t border-border">
         <div className="mx-auto max-w-5xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               The difficult parts are already designed.
             </h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -175,7 +196,7 @@ export default function HomePage() {
       <section className="border-t border-border">
         <div className="mx-auto max-w-6xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               Try it here, not in a screenshot.
             </h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -212,7 +233,7 @@ export default function HomePage() {
       <section className="border-t border-border">
         <div className="mx-auto max-w-5xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               Every state included.
             </h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -231,11 +252,30 @@ export default function HomePage() {
         </div>
       </section>
 
+      {/* Free access — the lead magnet */}
+      <section id="access" className="border-t border-border scroll-mt-20">
+        <div className="mx-auto max-w-3xl px-4 py-20">
+          <ScrollFade>
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
+              Free while in beta.
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Every component — signature workflows included — is free to
+              integrate right now. In exchange, tell us what you&apos;re
+              building: it decides which components we design next.
+            </p>
+            <div className="mt-8">
+              <AccessForm />
+            </div>
+          </ScrollFade>
+        </div>
+      </section>
+
       {/* Installation */}
       <section className="border-t border-border">
         <div className="mx-auto max-w-3xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               Installation
             </h2>
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
@@ -253,7 +293,7 @@ export default function HomePage() {
       <section className="border-t border-border">
         <div className="mx-auto max-w-5xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               Why DUKU Labs
             </h2>
           </ScrollFade>
@@ -279,7 +319,7 @@ export default function HomePage() {
       <section className="border-t border-border">
         <div className="mx-auto max-w-5xl px-4 py-20">
           <ScrollFade>
-            <h2 className="text-2xl font-semibold tracking-tight">
+            <h2 className="font-pixel text-xl uppercase tracking-wide sm:text-2xl">
               The catalog
             </h2>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/app/(site)/pricing/page.tsx
+++ b/app/(site)/pricing/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { PricingContent } from "@/components/site/pricing-content";
 
 export const metadata: Metadata = { title: "Pricing" };
@@ -6,7 +7,23 @@ export const metadata: Metadata = { title: "Pricing" };
 export default function PricingPage() {
   return (
     <main className="mx-auto max-w-5xl px-4 py-20">
-      <h1 className="text-center text-3xl font-semibold tracking-tight">
+      <div className="pixel-frame mx-auto mb-10 max-w-2xl bg-card p-4 text-center">
+        <p className="font-pixel text-xs uppercase tracking-widest text-success">
+          ▚ Free while in beta
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Every component is free to integrate today —{" "}
+          <Link
+            href="/#access"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            grab access
+          </Link>{" "}
+          and tell us what you&apos;re building. The tiers below are what
+          pricing will look like at 1.0.
+        </p>
+      </div>
+      <h1 className="text-center font-pixel text-2xl uppercase tracking-wide sm:text-3xl">
         Simple pricing
       </h1>
       <p className="mt-3 text-center text-sm text-muted-foreground">

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Lead capture for the free-access form. Components stay free to
+ * integrate; this is the lead magnet that tells us who's building what.
+ *
+ * Storage: if DUKU_LEADS_WEBHOOK is set (e.g. a Slack webhook, Airtable
+ * automation or CRM endpoint), the lead is forwarded there as JSON.
+ * Without it the lead is logged server-side only — wire the env var
+ * before launch.
+ */
+
+interface Lead {
+  email: string;
+  building: string;
+  purposes: string[];
+  role?: string;
+}
+
+export async function POST(req: NextRequest) {
+  let body: Partial<Lead>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const email = String(body.email ?? "").trim();
+  const building = String(body.building ?? "").trim();
+  const purposes = Array.isArray(body.purposes)
+    ? body.purposes.map(String).slice(0, 10)
+    : [];
+  const role = body.role ? String(body.role).trim().slice(0, 120) : undefined;
+
+  if (!/^\S+@\S+\.\S+$/.test(email)) {
+    return NextResponse.json(
+      { ok: false, error: "Enter a valid email." },
+      { status: 400 }
+    );
+  }
+  if (building.length < 3) {
+    return NextResponse.json(
+      { ok: false, error: "Tell us a little about what you're building." },
+      { status: 400 }
+    );
+  }
+
+  const lead: Lead & { at: string; source: string } = {
+    email,
+    building: building.slice(0, 2000),
+    purposes,
+    ...(role ? { role } : {}),
+    at: new Date().toISOString(),
+    source: "labs.duku.design/#access",
+  };
+
+  const webhook = process.env.DUKU_LEADS_WEBHOOK;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(lead),
+      });
+    } catch (err) {
+      // Don't lose the signup because the webhook hiccuped.
+      console.error("[leads] webhook forward failed:", err);
+    }
+  }
+  console.log("[leads]", JSON.stringify(lead));
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -95,6 +95,9 @@
 }
 
 @theme inline {
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
+  --font-pixel: var(--font-geist-pixel-square), ui-monospace, monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -197,4 +200,48 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-feature-settings: "rlig" 1, "calt" 1;
+}
+
+/* ---- Pixel art direction ------------------------------------------- */
+
+/* Hard-edged frame: no radius, stepped drop shadow. */
+.pixel-frame {
+  border: 2px solid var(--border);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 0 var(--border);
+}
+
+/* CRT scanlines over media/animation surfaces. */
+.scanlines {
+  position: relative;
+}
+.scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0 2px,
+    rgb(0 0 0 / 0.05) 2px 3px
+  );
+}
+.dark .scanlines::after {
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0 2px,
+    rgb(255 255 255 / 0.04) 2px 3px
+  );
+}
+
+/* Checkerboard dither strip, used as a section divider. */
+.pixel-divider {
+  height: 8px;
+  background: repeating-conic-gradient(var(--border) 0% 25%, transparent 0% 50%);
+  background-size: 8px 8px;
+}
+
+/* Keep raster/pixel assets crisp when scaled. */
+.pixelated {
+  image-rendering: pixelated;
 }

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
+  <style>
+    .px { fill: #09090b; }
+    @media (prefers-color-scheme: dark) { .px { fill: #fafafa; } }
+  </style>
+  <rect class="px" x="0" y="0" width="2" height="8"/>
+  <rect class="px" x="2" y="0" width="3" height="1"/>
+  <rect class="px" x="2" y="7" width="3" height="1"/>
+  <rect class="px" x="5" y="1" width="2" height="6"/>
+  <rect x="8" y="0" width="1" height="1" fill="#10b981"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
+import { GeistPixelSquare } from "geist/font/pixel";
 import { Toaster } from "@/registry/default/ui/toast";
 import "./globals.css";
 
@@ -17,7 +20,11 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${GeistSans.variable} ${GeistMono.variable} ${GeistPixelSquare.variable}`}
+    >
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}

--- a/components/site/access-form.tsx
+++ b/components/site/access-form.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import * as React from "react";
+import gsap from "gsap";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/registry/default/lib/use-reduced-motion";
+import { Button } from "@/registry/default/ui/button";
+import { Input } from "@/registry/default/ui/input";
+import { Textarea } from "@/registry/default/ui/textarea";
+import { Field } from "@/registry/default/ui/field";
+import { CopyButton } from "@/registry/default/ui/kbd";
+
+const PURPOSES = [
+  "Fintech & markets",
+  "Payments & banking",
+  "Healthcare",
+  "AI agents",
+  "Enterprise ops",
+  "Side project",
+] as const;
+
+const MCP_CMD = "claude mcp add duku-labs --transport http https://labs.duku.design/mcp";
+const CLI_CMD = "npx shadcn@latest add https://labs.duku.design/r/kyc-flow.json";
+
+/**
+ * The lead magnet: everything is free while we're in beta — we just want
+ * to know who's building what. Success morphs straight into the install
+ * commands, so the reward for telling us is immediate.
+ */
+export function AccessForm({ className }: { className?: string }) {
+  const reduced = useReducedMotion();
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  const [email, setEmail] = React.useState("");
+  const [building, setBuilding] = React.useState("");
+  const [purposes, setPurposes] = React.useState<string[]>([]);
+  const [role, setRole] = React.useState("");
+  const [errors, setErrors] = React.useState<{ email?: string; building?: string }>({});
+  const [pending, setPending] = React.useState(false);
+  const [done, setDone] = React.useState(false);
+  const [serverError, setServerError] = React.useState<string | null>(null);
+
+  const togglePurpose = (p: string) =>
+    setPurposes((cur) => (cur.includes(p) ? cur.filter((x) => x !== p) : [...cur, p]));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const next: typeof errors = {};
+    if (!/^\S+@\S+\.\S+$/.test(email)) next.email = "Enter a valid email.";
+    if (building.trim().length < 3) next.building = "A sentence is plenty — what are you making?";
+    setErrors(next);
+    if (Object.keys(next).length) return;
+
+    setPending(true);
+    setServerError(null);
+    try {
+      const res = await fetch("/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, building, purposes, role: role || undefined }),
+      });
+      const json = await res.json();
+      if (!json.ok) throw new Error(json.error ?? "Something went wrong.");
+      // Blur-morph the form into the reward panel.
+      if (!reduced && rootRef.current) {
+        await new Promise<void>((resolve) => {
+          gsap.to(rootRef.current, {
+            opacity: 0,
+            filter: "blur(6px)",
+            duration: 0.25,
+            ease: "power2.in",
+            onComplete: resolve,
+          });
+        });
+      }
+      setDone(true);
+      if (!reduced && rootRef.current) {
+        gsap.fromTo(
+          rootRef.current,
+          { opacity: 0, filter: "blur(6px)", y: 10 },
+          { opacity: 1, filter: "blur(0px)", y: 0, duration: 0.4, ease: "power3.out", clearProps: "filter" }
+        );
+      }
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      data-slot="access-form"
+      className={cn("pixel-frame bg-card p-5 sm:p-6", className)}
+    >
+      {done ? (
+        <div>
+          <p className="font-pixel text-sm uppercase tracking-widest text-success">
+            ▚ Access granted
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Everything below is yours — all {""}components, free while we&apos;re
+            in beta. We&apos;ll email you when new domain packs land.
+          </p>
+          <div className="mt-4 flex flex-col gap-2">
+            <p className="font-pixel text-[10px] uppercase tracking-widest text-muted-foreground">
+              Connect your agent
+            </p>
+            <div className="flex items-center justify-between gap-2 overflow-x-auto rounded-none border border-border bg-muted/50 py-1.5 pl-3 pr-1.5">
+              <code className="whitespace-nowrap font-mono text-[12px] text-foreground">{MCP_CMD}</code>
+              <CopyButton value={MCP_CMD} />
+            </div>
+            <p className="mt-1 font-pixel text-[10px] uppercase tracking-widest text-muted-foreground">
+              Or install a component
+            </p>
+            <div className="flex items-center justify-between gap-2 overflow-x-auto rounded-none border border-border bg-muted/50 py-1.5 pl-3 pr-1.5">
+              <code className="whitespace-nowrap font-mono text-[12px] text-foreground">{CLI_CMD}</code>
+              <CopyButton value={CLI_CMD} />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="flex flex-col gap-4" aria-label="Get free access">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Email" state={errors.email ? "error" : null} message={errors.email}>
+              <Input
+                type="email"
+                value={email}
+                invalid={!!errors.email}
+                autoComplete="email"
+                placeholder="you@company.com"
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setErrors((x) => ({ ...x, email: undefined }));
+                }}
+              />
+            </Field>
+            <Field label="Role / company (optional)">
+              <Input
+                value={role}
+                placeholder="Design engineer @ …"
+                onChange={(e) => setRole(e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <Field
+            label="What product are you building?"
+            state={errors.building ? "error" : null}
+            message={errors.building}
+          >
+            <Textarea
+              value={building}
+              rows={2}
+              maxRows={5}
+              invalid={!!errors.building}
+              placeholder="A broking app with an options screen… a patient portal… an agent console…"
+              onChange={(e) => {
+                setBuilding(e.target.value);
+                setErrors((x) => ({ ...x, building: undefined }));
+              }}
+            />
+          </Field>
+
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              What do you want the library for?
+            </p>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {PURPOSES.map((p) => {
+                const on = purposes.includes(p);
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => togglePurpose(p)}
+                    className={cn(
+                      "border px-2.5 py-1 font-pixel text-[10px] uppercase tracking-wider transition-colors duration-150",
+                      on
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-background text-muted-foreground hover:text-foreground",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    )}
+                  >
+                    {p}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {serverError ? (
+            <p role="alert" className="text-xs font-medium text-destructive">
+              {serverError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="max-w-[36ch] text-[11px] leading-4 text-muted-foreground">
+              Free while in beta. No card, no key — your answers shape which
+              components we build next.
+            </p>
+            <Button type="submit" loading={pending}>
+              Get free access
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/components/site/ascii-showcase.tsx
+++ b/components/site/ascii-showcase.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/registry/default/lib/use-reduced-motion";
+
+/**
+ * The whole product, drawn in pixels.
+ *
+ * A character-grid canvas that plays five ASCII scenes — option chain,
+ * KYC journey, live vitals, swap route, agent run — with an ordered-dither
+ * dissolve between them. Colors come from the live CSS tokens so it
+ * re-paints for light/dark; reduced motion gets a single settled frame.
+ */
+
+/* ---------------- char-grid model ---------------- */
+
+type Ink =
+  | "fg" // foreground
+  | "mut" // muted-foreground
+  | "up" // market-up
+  | "down" // market-down
+  | "bid"
+  | "ask"
+  | "warn"
+  | "info"
+  | "success";
+
+interface Cell {
+  ch: string;
+  ink: Ink;
+}
+
+class Grid {
+  cells: Cell[];
+  constructor(
+    public cols: number,
+    public rows: number
+  ) {
+    this.cells = Array.from({ length: cols * rows }, () => ({ ch: " ", ink: "fg" }));
+  }
+  put(x: number, y: number, ch: string, ink: Ink = "fg") {
+    if (x < 0 || y < 0 || x >= this.cols || y >= this.rows) return;
+    const c = this.cells[(y | 0) * this.cols + (x | 0)];
+    if (!c) return;
+    c.ch = ch;
+    c.ink = ink;
+  }
+  text(x: number, y: number, s: string, ink: Ink = "fg") {
+    for (let i = 0; i < s.length; i++) this.put(x + i, y, s[i], ink);
+  }
+  /** Horizontal bar of block glyphs with a dithered tip. */
+  bar(x: number, y: number, len: number, max: number, ink: Ink) {
+    const full = Math.floor(len);
+    for (let i = 0; i < Math.min(full, max); i++) this.put(x + i, y, "█", ink);
+    const frac = len - full;
+    if (full < max && frac > 0.2) this.put(x + full, y, frac > 0.66 ? "▓" : "▒", ink);
+  }
+  clear() {
+    for (const c of this.cells) {
+      c.ch = " ";
+      c.ink = "fg";
+    }
+  }
+}
+
+/* ---------------- scenes ---------------- */
+
+type Scene = { name: string; draw: (g: Grid, t: number) => void };
+
+const wob = (t: number, seed: number, amp = 1) =>
+  Math.sin(t * 1.7 + seed * 12.9898) * amp;
+
+const SCENES: Scene[] = [
+  {
+    name: "OPTION CHAIN",
+    draw(g, t) {
+      const spot = 24812 + Math.round(wob(t, 1, 14));
+      g.text(1, 0, "NIFTY", "fg");
+      g.text(7, 0, String(spot), wob(t, 1) >= 0 ? "up" : "down");
+      g.text(g.cols - 10, 0, "17 JUL ▾", "mut");
+      g.text(1, 1, "CALLS", "bid");
+      g.text(g.cols - 5, 1, "PUTS", "ask");
+      const mid = Math.floor(g.cols / 2);
+      const strikes = [24700, 24750, 24800, 24850, 24900];
+      strikes.forEach((k, i) => {
+        const y = 2 + i;
+        const atm = k === 24800;
+        const cw = 6 + wob(t, i, 3.2) + (atm ? 3 : 0);
+        const pw = 5 + wob(t, i + 9, 3.2) + (atm ? 3 : 0);
+        g.bar(mid - 4 - Math.min(9, Math.max(1, cw)), y, Math.min(9, Math.max(1, cw)), 9, "bid");
+        g.text(mid - 2, y, String(k), atm ? "fg" : "mut");
+        g.bar(mid + 4, y, Math.min(9, Math.max(1, pw)), 9, "ask");
+        if (atm) g.text(mid - 2, y + 0, String(k), "fg");
+        if (atm) g.text(1, y, "ATM▸", "warn");
+      });
+      g.text(1, g.rows - 1, "Δ 0.53  Θ -19.1  OI 24.1L", "mut");
+    },
+  },
+  {
+    name: "KYC JOURNEY",
+    draw(g, t) {
+      const steps = ["DETAILS", "PAN", "DOCS", "LIVENESS", "REVIEW"];
+      const phase = Math.min(steps.length, 1 + Math.floor((t % 6) * 1.1));
+      g.text(1, 0, "IDENTITY VERIFICATION", "fg");
+      steps.forEach((s, i) => {
+        const y = 2 + i;
+        const done = i < phase;
+        const active = i === phase;
+        g.put(2, y, done ? "█" : active ? "▓" : "░", done ? "success" : active ? "info" : "mut");
+        g.text(4, y, s, done || active ? "fg" : "mut");
+        if (done) g.text(4 + s.length + 1, y, "✓", "success");
+        if (active) g.text(4 + s.length + 1, y, ["|", "/", "-", "\\"][Math.floor(t * 8) % 4], "info");
+      });
+      const total = Math.round(((phase) / steps.length) * (g.cols - 4));
+      g.bar(2, g.rows - 2, total, g.cols - 4, "success");
+      g.text(1, g.rows - 1, phase >= 5 ? "MANUAL REVIEW · a specialist is looking" : "every state designed — even the retakes", phase >= 5 ? "warn" : "mut");
+    },
+  },
+  {
+    name: "LIVE VITALS",
+    draw(g, t) {
+      g.text(1, 0, "BED 12", "fg");
+      const hr = 72 + Math.round(wob(t, 3, 2));
+      g.text(g.cols - 8, 0, `${hr} BPM`, "success");
+      // ECG: one beat scrolling across the mid rows
+      const midY = Math.floor(g.rows / 2);
+      for (let x = 1; x < g.cols - 1; x++) {
+        const ph = ((x + t * 14) % 24) / 24; // beat period
+        let dy = 0;
+        if (ph > 0.32 && ph < 0.37) dy = -1;
+        else if (ph >= 0.37 && ph < 0.42) dy = -3;
+        else if (ph >= 0.42 && ph < 0.47) dy = 1;
+        else if (ph > 0.6 && ph < 0.7) dy = -1;
+        const y = midY + dy;
+        g.put(x, y, dy === -3 ? "█" : dy !== 0 ? "▓" : "░", "success");
+      }
+      g.text(1, g.rows - 2, "SPO₂ 98%   BP 122/78   36.8°C", "mut");
+      g.text(1, g.rows - 1, "all vitals in range", "success");
+    },
+  },
+  {
+    name: "CRYPTO SWAP",
+    draw(g, t) {
+      g.text(1, 0, "SWAP 1,000 USDT → ETH", "fg");
+      const hops = ["USDT", "USDC", "WETH", "ETH"];
+      const y = Math.floor(g.rows / 2) - 1;
+      const seg = Math.floor((g.cols - 8) / (hops.length - 1));
+      hops.forEach((h, i) => {
+        const x = 3 + i * seg;
+        g.text(x, y, `[${h}]`, i === hops.length - 1 ? "up" : "fg");
+        if (i < hops.length - 1)
+          for (let d = h.length + 2; d < seg; d++) g.put(x + d, y, "·", "mut");
+      });
+      // packet travelling the route
+      const total = seg * (hops.length - 1);
+      const p = Math.floor((t * 10) % total);
+      g.put(3 + p, y, "█", "info");
+      g.text(1, y + 2, "rate 1 ETH = 3,412.60   impact 0.05%", "mut");
+      g.text(1, g.rows - 1, "approve → swap → confirmed on-chain", "mut");
+    },
+  },
+  {
+    name: "AGENT RUN",
+    draw(g, t) {
+      g.text(1, 0, "GOAL: refund order #8412", "fg");
+      const lines: [string, Ink][] = [
+        ["▸ search_components", "info"],
+        ["✓ orders.get         312ms", "success"],
+        ["✓ payments.refund    1.2s", "success"],
+        ["⧗ approval gate — waiting", "warn"],
+        ["✓ email.send         queued", "success"],
+      ];
+      const shown = Math.min(lines.length, 1 + Math.floor((t % 6) * 1.2));
+      for (let i = 0; i < shown; i++) {
+        const [s, ink] = lines[i];
+        const isLast = i === shown - 1 && shown < lines.length;
+        g.text(2, 2 + i, isLast ? s.slice(0, 1 + Math.floor((t * 20) % s.length)) : s, ink);
+      }
+      if (shown >= lines.length) g.text(2, g.rows - 1, "ARTIFACT: refund_51ab complete ✓", "up");
+      else g.text(2, g.rows - 1, "12.4k tokens · $0.08", "mut");
+    },
+  },
+];
+
+/* 4×4 Bayer matrix for the dither dissolve between scenes. */
+const BAYER = [0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5];
+
+/* ---------------- component ---------------- */
+
+export interface AsciiShowcaseProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Seconds per scene. Default 6. */
+  sceneSeconds?: number;
+}
+
+export function AsciiShowcase({
+  className,
+  sceneSeconds = 6,
+  ...rest
+}: AsciiShowcaseProps) {
+  const reduced = useReducedMotion();
+  const wrapRef = React.useRef<HTMLDivElement>(null);
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const [label, setLabel] = React.useState(SCENES[0].name);
+
+  React.useEffect(() => {
+    const wrap = wrapRef.current;
+    const canvas = canvasRef.current;
+    if (!wrap || !canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let stopped = false;
+
+    const readInks = (): Record<Ink, string> => {
+      const s = getComputedStyle(wrap);
+      const v = (name: string) => s.getPropertyValue(name).trim();
+      return {
+        fg: v("--foreground"),
+        mut: v("--muted-foreground"),
+        up: v("--market-up"),
+        down: v("--market-down"),
+        bid: v("--bid"),
+        ask: v("--ask"),
+        warn: v("--warning"),
+        info: v("--info"),
+        success: v("--success"),
+      };
+    };
+
+    let inks = readInks();
+    const font = getComputedStyle(wrap).fontFamily;
+
+    const CW = 11; // cell width px
+    const CH = 20; // cell height px
+    let grid: Grid;
+    let next: Grid;
+
+    const size = () => {
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      const w = wrap.clientWidth;
+      const h = wrap.clientHeight;
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const cols = Math.max(24, Math.floor(w / CW));
+      const rows = Math.max(9, Math.floor(h / CH));
+      grid = new Grid(cols, rows);
+      next = new Grid(cols, rows);
+    };
+    size();
+
+    const paint = (g: Grid) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.font = `15px ${font}`;
+      ctx.textBaseline = "top";
+      for (let y = 0; y < g.rows; y++) {
+        for (let x = 0; x < g.cols; x++) {
+          const c = g.cells[y * g.cols + x];
+          if (c.ch === " ") continue;
+          ctx.fillStyle = inks[c.ink];
+          ctx.fillText(c.ch, x * CW, y * CH + 2);
+        }
+      }
+    };
+
+    if (reduced) {
+      // One settled frame of the first scene; still theme-aware.
+      const drawStill = () => {
+        inks = readInks();
+        grid.clear();
+        SCENES[0].draw(grid, 2.5);
+        paint(grid);
+      };
+      drawStill();
+      const mo = new MutationObserver(drawStill);
+      mo.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+      const ro = new ResizeObserver(() => {
+        size();
+        drawStill();
+      });
+      ro.observe(wrap);
+      return () => {
+        mo.disconnect();
+        ro.disconnect();
+      };
+    }
+
+    const start = performance.now();
+    let last = 0;
+    const FPS = 14; // deliberately chunky
+    const tick = (now: number) => {
+      if (stopped) return;
+      raf = requestAnimationFrame(tick);
+      if (now - last < 1000 / FPS) return;
+      last = now;
+      // rAF's first timestamp can predate our start capture — clamp.
+      const elapsed = Math.max(0, (now - start) / 1000);
+      const per = sceneSeconds;
+      const n = SCENES.length;
+      const idx = ((Math.floor(elapsed / per) % n) + n) % n;
+      const t = elapsed % per;
+      const scene = SCENES[idx];
+      if (!scene) return;
+      setLabel(scene.name);
+
+      grid.clear();
+      scene.draw(grid, t);
+
+      // Dither dissolve during the last 0.7s: mix in the next scene.
+      const tail = per - t;
+      if (tail < 0.7) {
+        const nextScene = SCENES[(idx + 1) % SCENES.length];
+        next.clear();
+        nextScene.draw(next, 0);
+        const threshold = (1 - tail / 0.7) * 16;
+        for (let y = 0; y < grid.rows; y++) {
+          for (let x = 0; x < grid.cols; x++) {
+            if (BAYER[(y % 4) * 4 + (x % 4)] < threshold) {
+              grid.cells[y * grid.cols + x] = next.cells[y * next.cols + x];
+            }
+          }
+        }
+      }
+      paint(grid);
+    };
+    raf = requestAnimationFrame(tick);
+
+    const mo = new MutationObserver(() => {
+      inks = readInks();
+    });
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    const ro = new ResizeObserver(size);
+    ro.observe(wrap);
+
+    return () => {
+      stopped = true;
+      cancelAnimationFrame(raf);
+      mo.disconnect();
+      ro.disconnect();
+    };
+  }, [reduced, sceneSeconds]);
+
+  return (
+    <div
+      data-slot="ascii-showcase"
+      className={cn(
+        "pixel-frame scanlines relative overflow-hidden bg-card",
+        className
+      )}
+      {...rest}
+    >
+      <div ref={wrapRef} className="h-72 w-full font-pixel sm:h-80" aria-hidden="true">
+        <canvas ref={canvasRef} className="block h-full w-full" />
+      </div>
+      <div className="pointer-events-none absolute bottom-2 right-3 font-pixel text-[10px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </div>
+      <p className="sr-only">
+        Animated pixel-art tour of DUKU Labs components: an option chain, a
+        KYC journey, live patient vitals, a crypto swap route and an agent
+        run.
+      </p>
+    </div>
+  );
+}

--- a/components/site/hero-intro.tsx
+++ b/components/site/hero-intro.tsx
@@ -65,13 +65,18 @@ export function HeroIntro() {
 
   return (
     <div ref={rootRef} className="flex flex-col items-center">
-      <div data-hero="badge" className="mb-6 opacity-0">
-        <Badge variant="outline" pulse>
+      <div data-hero="badge" className="mb-5 flex flex-col items-center gap-4 opacity-0">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/logo-light.svg" alt="" className="pixelated h-9 w-auto dark:hidden" />
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/logo-dark.svg" alt="" className="pixelated hidden h-9 w-auto dark:block" />
+        <Badge variant="outline" pulse className="font-pixel text-[10px] uppercase tracking-widest">
           Design engineering with AI
         </Badge>
       </div>
       <KineticHeading
         text="Interfaces your AI would not design by itself."
+        className="font-pixel text-3xl leading-snug tracking-tight sm:text-4xl md:text-5xl"
         delay={0.35}
       />
       <p
@@ -84,22 +89,22 @@ export function HeroIntro() {
         Claude Code or Codex discover, customise and implement the right
         interface directly in your codebase.
       </p>
-      <div data-hero="cta" className="mt-8 flex items-center gap-4 opacity-0">
-        <Link href="/connect">
-          <MagneticButton>Connect to MCP</MagneticButton>
+      <div data-hero="cta" className="mt-8 flex flex-wrap items-center justify-center gap-4 opacity-0">
+        <Link href="/#access">
+          <MagneticButton>Get free access</MagneticButton>
         </Link>
         <Link
-          href="/components/button"
+          href="/connect"
           className="text-sm font-medium text-foreground underline-offset-4 transition-colors duration-200 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          Explore the library
+          Connect to MCP
         </Link>
       </div>
       <p
         data-hero="proof"
-        className="mt-6 text-xs text-muted-foreground opacity-0"
+        className="mt-6 font-pixel text-[10px] uppercase tracking-widest text-muted-foreground opacity-0"
       >
-        Built for real products. Designed for every state. Yours to customise.
+        Real products · every state · yours to customise
       </p>
     </div>
   );

--- a/components/site/site-footer.tsx
+++ b/components/site/site-footer.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+
+/* One place to retune the ecosystem links. */
+const ECOSYSTEM = {
+  parent: { href: "https://www.duku.design", label: "duku.design" },
+  rubrik: { href: "https://rubrik.duku.design", label: "Duku Rubrik" },
+};
+
+function Ext({
+  href,
+  children,
+  sub,
+}: {
+  href: string;
+  children: React.ReactNode;
+  sub?: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="text-sm text-muted-foreground transition-colors duration-200 group-hover:text-foreground">
+        {children} <span aria-hidden="true">↗</span>
+      </span>
+      {sub ? (
+        <span className="block text-[11px] leading-4 text-muted-foreground/70">
+          {sub}
+        </span>
+      ) : null}
+    </a>
+  );
+}
+
+export function SiteFooter() {
+  return (
+    <footer className="mt-10">
+      <div className="pixel-divider" aria-hidden="true" />
+      <div className="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Brand */}
+        <div>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/logo-light.svg" alt="" className="pixelated h-6 w-auto dark:hidden" />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/logo-dark.svg" alt="" className="pixelated hidden h-6 w-auto dark:block" />
+            <span className="font-pixel text-sm tracking-wider text-foreground">
+              DUKU LABS
+            </span>
+          </Link>
+          <p className="mt-3 max-w-[26ch] font-pixel text-[11px] leading-5 tracking-wide text-muted-foreground">
+            DESIGN ENGINEERING FOR AI-BUILT PRODUCTS
+          </p>
+        </div>
+
+        {/* Product */}
+        <div>
+          <p className="font-pixel text-[11px] uppercase tracking-widest text-muted-foreground">
+            Product
+          </p>
+          <ul className="mt-3 flex flex-col gap-2">
+            {[
+              ["/components/kyc-flow", "Components"],
+              ["/connect", "Connect to MCP"],
+              ["/pricing", "Pricing"],
+              ["/#access", "Get free access"],
+            ].map(([href, label]) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="rounded-md text-sm text-muted-foreground transition-colors duration-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Ecosystem */}
+        <div>
+          <p className="font-pixel text-[11px] uppercase tracking-widest text-muted-foreground">
+            Ecosystem
+          </p>
+          <ul className="mt-3 flex flex-col gap-3">
+            <li>
+              <Ext href={ECOSYSTEM.parent.href} sub="The studio behind DUKU Labs">
+                {ECOSYSTEM.parent.label}
+              </Ext>
+            </li>
+            <li>
+              <Ext
+                href={ECOSYSTEM.rubrik.href}
+                sub="Audits your complete product — design, states, accessibility"
+              >
+                {ECOSYSTEM.rubrik.label}
+              </Ext>
+            </li>
+          </ul>
+        </div>
+
+        {/* Agents */}
+        <div>
+          <p className="font-pixel text-[11px] uppercase tracking-widest text-muted-foreground">
+            For agents
+          </p>
+          <p className="mt-3 font-mono text-[11px] leading-5 text-muted-foreground">
+            claude mcp add duku-labs
+            <br />
+            --transport http
+            <br />
+            https://labs.duku.design/mcp
+          </p>
+        </div>
+      </div>
+      <div className="border-t border-border">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-2 px-4 py-4">
+          <p className="font-pixel text-[10px] tracking-wider text-muted-foreground">
+            © {new Date().getFullYear()} DUKU · MADE WITH HUMAN TASTE
+          </p>
+          <p className="font-pixel text-[10px] tracking-wider text-muted-foreground">
+            FREE WHILE IN BETA
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/site/site-nav.tsx
+++ b/components/site/site-nav.tsx
@@ -30,9 +30,15 @@ export function SiteNav() {
       logo={
         <Link
           href="/"
-          className="text-sm font-semibold tracking-tight text-foreground"
+          className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          DUKU<span className="text-muted-foreground"> Labs</span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/logo-light.svg" alt="DUKU" className="pixelated h-5 w-auto dark:hidden" />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/logo-dark.svg" alt="DUKU" className="pixelated hidden h-5 w-auto dark:block" />
+          <span className="font-pixel text-xs tracking-wider text-foreground">
+            DUKU LABS
+          </span>
         </Link>
       }
       cta={<ThemeToggle />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "geist": "^1.7.2",
         "gsap": "^3.12.7",
         "motion": "^12.15.0",
         "next": "^15.3.9",
@@ -7911,6 +7912,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.2.tgz",
+      "integrity": "sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.7.2",
     "gsap": "^3.12.7",
     "motion": "^12.15.0",
     "next": "^15.3.9",

--- a/public/logo-dark.svg
+++ b/public/logo-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
+  <!-- DUKU pixel mark — dark-background variant.
+       Replace this file with the real logo; keep the filename. -->
+  <rect x="0" y="0" width="2" height="8" fill="#fafafa"/>
+  <rect x="2" y="0" width="3" height="1" fill="#fafafa"/>
+  <rect x="2" y="7" width="3" height="1" fill="#fafafa"/>
+  <rect x="5" y="1" width="2" height="6" fill="#fafafa"/>
+  <rect x="8" y="0" width="1" height="1" fill="#34d399"/>
+</svg>

--- a/public/logo-light.svg
+++ b/public/logo-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
+  <!-- DUKU pixel mark — light-background variant.
+       Replace this file with the real logo; keep the filename. -->
+  <rect x="0" y="0" width="2" height="8" fill="#09090b"/>
+  <rect x="2" y="0" width="3" height="1" fill="#09090b"/>
+  <rect x="2" y="7" width="3" height="1" fill="#09090b"/>
+  <rect x="5" y="1" width="2" height="6" fill="#09090b"/>
+  <rect x="8" y="0" width="1" height="1" fill="#059669"/>
+</svg>


### PR DESCRIPTION
Art-directed pixel pass on the landing experience.

## Type & art system
- **Geist Pixel (Square)** wired via `geist/font/pixel` (real Vercel font, not a lookalike) alongside Geist Sans/Mono
- `font-pixel` utility + `pixel-frame` (hard-edged stepped shadow), `scanlines` (CRT overlay, theme-aware), `pixel-divider` (checkerboard dither), `pixelated` CSS utilities

## The centerpiece — `ascii-showcase`
A character-grid canvas that draws **the whole product in pixels**: option chain with breathing ATM bars → KYC journey with step checks → live ECG vitals → swap route with a travelling packet → an agent run typing out. Scenes hand off through an ordered-Bayer dither dissolve at a deliberately chunky 14fps. Colors read the live CSS tokens so it re-paints for light/dark; reduced motion gets a settled static frame; an sr-only description covers assistive tech.

## Logos
Pixel DUKU marks at `public/logo-light.svg` / `public/logo-dark.svg` — used in nav, hero and footer with dark-mode swapping, plus an adaptive SVG favicon (`app/icon.svg`). These are crafted placeholders at fixed paths: **drop the real logo files over them (same filenames) and everything picks them up.**

## Lead magnet (free stays free)
Components remain free to integrate in beta. `AccessForm` (#access) collects **email, what product they're building, purpose chips (fintech/payments/healthcare/AI agents/enterprise/side project) and optional role** → POSTs to `/api/leads` (forwards to `DUKU_LEADS_WEBHOOK` when set) → morphs straight into the MCP + install commands as the reward. Hero CTA is now "Get free access"; pricing page gets a "Free while in beta" banner framing tiers as 1.0 pricing.

## Footer (all pages)
Brand block, product links, **ecosystem links to www.duku.design (parent studio) and Duku Rubrik ("audits your complete product")**, agent connect snippet, dither divider.

## Fix found while verifying
Canvas loop crashed when rAF's first timestamp predated the start capture (scene index −1) — clamped and guarded.

## Verification
10/10 headless checks: Geist Pixel computed on the H1, canvas frames advance + scenes cycle, light/dark logo swap, footer links, form validation → submit → reward, pricing banner, reduced-motion static frame. Zero console/page errors. Build green (78 pages).

Note: the Rubrik URL is set to `https://rubrik.duku.design` in one config const in `site-footer.tsx` — trivially changeable if the real URL differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MR8LdM4Akm9wV3uyFTwF42

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR8LdM4Akm9wV3uyFTwF42)_