### PR TITLE
Use the real DUKU Labs logo lockups

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
   <style>
-    .px { fill: #09090b; }
-    @media (prefers-color-scheme: dark) { .px { fill: #fafafa; } }
+    .px { fill: #090909; }
+    @media (prefers-color-scheme: dark) { .px { fill: #ffffff; } }
   </style>
   <rect class="px" x="0" y="0" width="2" height="8"/>
   <rect class="px" x="2" y="0" width="3" height="1"/>
   <rect class="px" x="2" y="7" width="3" height="1"/>
   <rect class="px" x="5" y="1" width="2" height="6"/>
-  <rect x="8" y="0" width="1" height="1" fill="#10b981"/>
+  <rect x="8" y="0" width="1" height="1" fill="#FF4400"/>
 </svg>

--- a/components/site/hero-intro.tsx
+++ b/components/site/hero-intro.tsx
@@ -67,9 +67,9 @@ export function HeroIntro() {
     <div ref={rootRef} className="flex flex-col items-center">
       <div data-hero="badge" className="mb-5 flex flex-col items-center gap-4 opacity-0">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/logo-light.svg" alt="" className="pixelated h-9 w-auto dark:hidden" />
+        <img src="/duku_labs_light.svg" alt="DUKU Labs" className="h-9 w-auto dark:hidden sm:h-11" />
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/logo-dark.svg" alt="" className="pixelated hidden h-9 w-auto dark:block" />
+        <img src="/duku_labs_dark.svg" alt="DUKU Labs" className="hidden h-9 w-auto dark:block sm:h-11" />
         <Badge variant="outline" pulse className="font-pixel text-[10px] uppercase tracking-widest">
           Design engineering with AI
         </Badge>

--- a/components/site/site-footer.tsx
+++ b/components/site/site-footer.tsx
@@ -43,15 +43,12 @@ export function SiteFooter() {
         <div>
           <Link
             href="/"
-            className="inline-flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/logo-light.svg" alt="" className="pixelated h-6 w-auto dark:hidden" />
+            <img src="/duku_labs_light.svg" alt="DUKU Labs" className="h-7 w-auto dark:hidden" />
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/logo-dark.svg" alt="" className="pixelated hidden h-6 w-auto dark:block" />
-            <span className="font-pixel text-sm tracking-wider text-foreground">
-              DUKU LABS
-            </span>
+            <img src="/duku_labs_dark.svg" alt="DUKU Labs" className="hidden h-7 w-auto dark:block" />
           </Link>
           <p className="mt-3 max-w-[26ch] font-pixel text-[11px] leading-5 tracking-wide text-muted-foreground">
             DESIGN ENGINEERING FOR AI-BUILT PRODUCTS

--- a/components/site/site-nav.tsx
+++ b/components/site/site-nav.tsx
@@ -30,15 +30,12 @@ export function SiteNav() {
       logo={
         <Link
           href="/"
-          className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/logo-light.svg" alt="DUKU" className="pixelated h-5 w-auto dark:hidden" />
+          <img src="/duku_labs_light.svg" alt="DUKU Labs" className="h-6 w-auto dark:hidden" />
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/logo-dark.svg" alt="DUKU" className="pixelated hidden h-5 w-auto dark:block" />
-          <span className="font-pixel text-xs tracking-wider text-foreground">
-            DUKU LABS
-          </span>
+          <img src="/duku_labs_dark.svg" alt="DUKU Labs" className="hidden h-6 w-auto dark:block" />
         </Link>
       }
       cta={<ThemeToggle />}

--- a/public/logo-dark.svg
+++ b/public/logo-dark.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
-  <!-- DUKU pixel mark — dark-background variant.
-       Replace this file with the real logo; keep the filename. -->
-  <rect x="0" y="0" width="2" height="8" fill="#fafafa"/>
-  <rect x="2" y="0" width="3" height="1" fill="#fafafa"/>
-  <rect x="2" y="7" width="3" height="1" fill="#fafafa"/>
-  <rect x="5" y="1" width="2" height="6" fill="#fafafa"/>
-  <rect x="8" y="0" width="1" height="1" fill="#34d399"/>
-</svg>

--- a/public/logo-light.svg
+++ b/public/logo-light.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" shape-rendering="crispEdges">
-  <!-- DUKU pixel mark — light-background variant.
-       Replace this file with the real logo; keep the filename. -->
-  <rect x="0" y="0" width="2" height="8" fill="#09090b"/>
-  <rect x="2" y="0" width="3" height="1" fill="#09090b"/>
-  <rect x="2" y="7" width="3" height="1" fill="#09090b"/>
-  <rect x="5" y="1" width="2" height="6" fill="#09090b"/>
-  <rect x="8" y="0" width="1" height="1" fill="#059669"/>
-</svg>


### PR DESCRIPTION
Swaps the placeholder pixel marks for the supplied brand logos.

- `duku_labs_light.svg` (black `#090909` ink) and `duku_labs_dark.svg` (white ink) — the running-figure **D /labs** lockup, both carrying the `#FF4400` brand accent
- These are full wordmark lockups (2193×651), so the adjacent "DUKU LABS" pixel text is dropped in the nav and footer; sizing set per placement (nav `h-6`, hero `h-9`/`sm:h-11`, footer `h-7`)
- Removed the now-unused `logo-{light,dark}.svg` placeholders; matched the SVG favicon accent to the brand orange

Verified in a headless browser: the correct variant renders in light mode, cleanly swaps to the white-ink lockup on dark-mode toggle (3 instances: nav, hero, footer), all load at native 2193×651, zero page errors. Build green (78 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MR8LdM4Akm9wV3uyFTwF42

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR8LdM4Akm9wV3uyFTwF42)_